### PR TITLE
pins sparklyr r pkg version to 1.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ aws.s3 aws.ec2metadata logging zip xlsx openxlsx svDialogs janitor rapportools l
 pacman bupaR distill blogdown pkgdown ggrepel rms filesstrings cowplot anytime flexdashboard dygraphs ISOweek gdata \
 Benchmarking DiceKriging DiceOptim eventdataR formattable ggiraph gtools heuristicsmineR lhs maditr NLP pheatmap \
 processanimateR processmapR processmonitR qdap RColourBrewer readxl rgdal shinydashboard syuzhet textclean \
-textreuse tictoc tidytext TM topicmodels wordcloud xesreadR sparklyr stringi pm4py purrr RODBCDBI
+textreuse tictoc tidytext tm topicmodels wordcloud xesreadR stringi pm4py purrr RODBCDBI
 
 
 RUN apt-get -y update  && apt-get install -y libcups2 libcups2-dev openjdk-11-jdk systemd python3 python3-pip \

--- a/install_r_packages.sh
+++ b/install_r_packages.sh
@@ -12,3 +12,6 @@ done;
 
 PCK="${PCK%?}"; # Remove last comma
 R -e "install.packages(c(${PCK}), repos='https://cran.rstudio.com/', dependencies=TRUE, Ncpus=parallel::detectCores(), quiet=TRUE)"
+
+# pin sparklyr pkg version to 1.6.2
+R -e "require(devtools); install_version('sparklyr', version = '1.6.2', repos='http://cran.rstudio.com/', dependencies=T, Ncpus=parallel::detectCores(), quiet=TRUE)"


### PR DESCRIPTION
- pins `sparklyr` pkg version to 1.6.2
- corrects case for `tm` pkg