### PR TITLE
Reenable Snyk

### DIFF
--- a/.github/workflows/pr_snyk.yml
+++ b/.github/workflows/pr_snyk.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Run Snyk to check image for high vulnerabilities
         uses: snyk/actions/docker@master
-        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
Removed the previous change that permitted snyk to complete with errors. This is to prevent any further R packages being inadvertently added until we have a proper solution.